### PR TITLE
Add simple SSR examples for Sveltekit

### DIFF
--- a/svelte/src/hooks.server.js
+++ b/svelte/src/hooks.server.js
@@ -1,0 +1,10 @@
+// Note: this file is required for the universal fetch handler
+
+/** @type {import('@sveltejs/kit').Handle} */
+export async function handle({ event, resolve }) {
+  const response = await resolve(event, {
+    filterSerializedResponseHeaders: (name) => name === "content-type",
+  });
+
+  return response;
+}

--- a/svelte/src/routes/+page.svelte
+++ b/svelte/src/routes/+page.svelte
@@ -66,6 +66,8 @@
     <header class="app-header">
         <h1>Eliza</h1>
         <h4>Svelte</h4>
+        <a href="/universal-ssr">Universal SSR Example</a>
+        <a href="/server-only-ssr">Server Only SSR Example</a>
     </header>
     <div class="container">
         {#each responses as resp}
@@ -141,6 +143,7 @@
         color: #000;
         background-color: #fff;
         border-bottom: 1px solid #ebebeb;
+        padding-bottom: 15px;
     }
     .eliza-resp-container {
         display: flex;

--- a/svelte/src/routes/server-only-ssr/+page.server.ts
+++ b/svelte/src/routes/server-only-ssr/+page.server.ts
@@ -1,0 +1,44 @@
+import { ElizaService } from '../../gen/buf/connect/demo/eliza/v1/eliza_connect';
+import { SayRequest } from '../../gen/buf/connect/demo/eliza/v1/eliza_pb';
+import { createGrpcWebTransport } from '@bufbuild/connect-web';
+import { createPromiseClient } from '@bufbuild/connect';
+import { wrapFetch } from '../../utils';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ fetch }) => {
+  const transport = createGrpcWebTransport({
+    baseUrl: 'https://demo.connect.build',
+    fetch: wrapFetch('calling from gRPC-web in server-only SSR', fetch),
+  });
+
+  const client = createPromiseClient(ElizaService, transport);
+
+  const request = {
+    sentence: "hi from the server",
+  };
+
+  const response = await client.say(new SayRequest(request));
+
+  /**
+   * The values on `response` (such as `sentence`) are regular JavaScript values.
+   * This means that we can easily pass them directly.
+   * The nice thing about doing this is that you retain full typing for `sentence: string`.
+   */
+  const plainProperty = response.sentence;
+  //    ^?
+
+
+  /**
+   * However, if we want to pass the entire response, we call `.toJson()` since what's passed through the SSR boundary must be plain JSON.
+   * The downside to this approach is that you lose all type information (but you can get it right back! see `SayResponse.fromJson` in +page.svelte).
+   * 
+   * You may also need to do this if you use BigInts or byte array (byte arrays use UInt8Array).
+   */
+  const fullResponseJson = response.toJson();
+
+  return {
+    request,
+    plainProperty,
+    fullResponseJson,
+  };
+}

--- a/svelte/src/routes/server-only-ssr/+page.server.ts
+++ b/svelte/src/routes/server-only-ssr/+page.server.ts
@@ -22,19 +22,23 @@ export const load: PageServerLoad = async ({ fetch }) => {
   /**
    * The values on `response` (such as `sentence`) are regular JavaScript values.
    * This means that we can easily pass them directly.
-   * The nice thing about doing this is that you retain full typing for `sentence: string`.
    */
   const plainProperty = response.sentence;
   //    ^?
+  //    The nice thing about doing this is that you retain full typing for `sentence: string`.
+
 
 
   /**
    * However, if we want to pass the entire response, we call `.toJson()` since what's passed through the SSR boundary must be plain JSON.
-   * The downside to this approach is that you lose all type information (but you can get it right back! see `SayResponse.fromJson` in +page.svelte).
    * 
    * You may also need to do this if you use BigInts or byte array (byte arrays use UInt8Array).
    */
   const fullResponseJson = response.toJson();
+  //    ^?
+  //    The downside to this approach is that you lose all type information and get `JsonValue`.
+  //    (but you can get it right back! see `SayResponse.fromJson` in +page.svelte)
+
 
   return {
     request,

--- a/svelte/src/routes/server-only-ssr/+page.svelte
+++ b/svelte/src/routes/server-only-ssr/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { SayResponse } from "../../gen/buf/connect/demo/eliza/v1/eliza_pb";
   import type { PageData } from "./$types";
 
   export let data: PageData = {
@@ -8,6 +9,12 @@
       sentence: 'uninitialized'
     }
   }
+
+  const sayResponse = SayResponse.fromJson(data.fullResponseJson);
+  //    ^?
+  //    If you wish to revive the response type, you can do so like this, by calling `.fromJson` on the Response class provided by protobuf-es.
+
+  console.log(data, sayResponse);
 </script>
 
 <div>

--- a/svelte/src/routes/server-only-ssr/+page.svelte
+++ b/svelte/src/routes/server-only-ssr/+page.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import type { PageData } from "./$types";
+
+  export let data: PageData = {
+    fullResponseJson: {},
+    plainProperty: 'uninitialized',
+    request: {
+      sentence: 'uninitialized'
+    }
+  }
+</script>
+
+<div>
+  <header class="app-header">
+      <h1>Eliza</h1>
+      <h4>Svelte</h4>
+      <a href="/">back</a>
+  </header>
+  <div class="container">
+    <h3>Server (only) Rendered Data</h3>
+    <div class="pre-container">
+        <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  </div>
+</div>
+
+<style>
+  h1 {
+      margin: 15px 0;
+      font-size: 3.5rem;
+  }
+  h4 {
+      margin: 0 0 15px 0;
+      color: #161ede;
+  }
+  .pre-container {
+    text-align: left;
+    display: flex;
+    justify-content: center;
+  }
+  .container {
+      text-align: center;
+      display: flex;
+      flex-direction: column;
+      font-size: 20px;
+      padding: 15px;
+      margin: 0 auto;
+      max-width: 1320px;
+      background-color: #fff;
+      min-height: 100vh;
+      border-left: 1px solid #ebebeb;
+      border-right: 1px solid #ebebeb;
+  }
+  .app-header {
+      display: flex;
+      justify-content: space-evenly;
+      flex-direction: column;
+      align-items: center;
+      color: #000;
+      background-color: #fff;
+      border-bottom: 1px solid #ebebeb;
+      padding-bottom: 15px;
+  }
+</style>

--- a/svelte/src/routes/server-only-ssr/+page.svelte
+++ b/svelte/src/routes/server-only-ssr/+page.svelte
@@ -14,7 +14,7 @@
   //    ^?
   //    If you wish to revive the response type, you can do so like this, by calling `.fromJson` on the Response class provided by protobuf-es.
 
-  console.log(data, sayResponse);
+  console.log("server-only-ssr +page.svelte", data, sayResponse);
 </script>
 
 <div>

--- a/svelte/src/routes/universal-ssr/+page.svelte
+++ b/svelte/src/routes/universal-ssr/+page.svelte
@@ -3,18 +3,20 @@
   import type { PageData } from "./$types";
 
   export let data: PageData = {
-    fullResponseJson: {},
-    plainProperty: 'uninitialized',
     request: {
       sentence: 'uninitialized'
-    }
+    },
+    plainProperty: 'uninitialized',
+    response: new SayResponse({
+      sentence: 'uninitialized'
+    }),
   }
 
-  const sayResponse = SayResponse.fromJson(data.fullResponseJson);
-  //    ^?
-  //    If you wish to revive the response type, you can do so like this, by calling `.fromJson` on the Response class provided by protobuf-es.
+  console.log("universal-ssr +page.svelte", data);
 
-  console.log(data, sayResponse);
+  data.response;
+  //   ^?
+  //   note that the full SayResponse Message type was able to pass through the SSR boundary in universal-ssr mode
 </script>
 
 <div>

--- a/svelte/src/routes/universal-ssr/+page.svelte
+++ b/svelte/src/routes/universal-ssr/+page.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+    import type { PageData } from "./$types";
+  
+    export let data: PageData = {
+      fullResponseJson: {},
+      plainProperty: 'uninitialized',
+      request: {
+        sentence: 'uninitialized'
+      }
+    }
+</script>
+
+<div>
+  <header class="app-header">
+      <h1>Eliza</h1>
+      <h4>Svelte</h4>
+      <a href="/">back</a>
+  </header>
+  <div class="container">
+    <h3>Universal SSR Rendered Data</h3>
+    <div class="pre-container">
+        <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  </div>
+</div>
+
+<style>
+  h1 {
+      margin: 15px 0;
+      font-size: 3.5rem;
+  }
+  h4 {
+      margin: 0 0 15px 0;
+      color: #161ede;
+  }
+  .pre-container {
+    text-align: left;
+    display: flex;
+    justify-content: center;
+  }
+  .container {
+      text-align: center;
+      display: flex;
+      flex-direction: column;
+      font-size: 20px;
+      padding: 15px;
+      margin: 0 auto;
+      max-width: 1320px;
+      background-color: #fff;
+      min-height: 100vh;
+      border-left: 1px solid #ebebeb;
+      border-right: 1px solid #ebebeb;
+  }
+  .app-header {
+      display: flex;
+      justify-content: space-evenly;
+      flex-direction: column;
+      align-items: center;
+      color: #000;
+      background-color: #fff;
+      border-bottom: 1px solid #ebebeb;
+      padding-bottom: 15px;
+  }
+</style>

--- a/svelte/src/routes/universal-ssr/+page.svelte
+++ b/svelte/src/routes/universal-ssr/+page.svelte
@@ -1,13 +1,20 @@
 <script lang="ts">
-    import type { PageData } from "./$types";
-  
-    export let data: PageData = {
-      fullResponseJson: {},
-      plainProperty: 'uninitialized',
-      request: {
-        sentence: 'uninitialized'
-      }
+  import { SayResponse } from "../../gen/buf/connect/demo/eliza/v1/eliza_pb";
+  import type { PageData } from "./$types";
+
+  export let data: PageData = {
+    fullResponseJson: {},
+    plainProperty: 'uninitialized',
+    request: {
+      sentence: 'uninitialized'
     }
+  }
+
+  const sayResponse = SayResponse.fromJson(data.fullResponseJson);
+  //    ^?
+  //    If you wish to revive the response type, you can do so like this, by calling `.fromJson` on the Response class provided by protobuf-es.
+
+  console.log(data, sayResponse);
 </script>
 
 <div>

--- a/svelte/src/routes/universal-ssr/+page.ts
+++ b/svelte/src/routes/universal-ssr/+page.ts
@@ -20,6 +20,8 @@ export const load: PageLoad = async ({ fetch }) => {
   };
 
   const response = await client.say(new SayRequest(request));
+  //    ^?
+  //    Note that the universal handler doesn't need
 
   /**
    * The values on `response` (such as `sentence`) are regular JavaScript values.
@@ -29,18 +31,9 @@ export const load: PageLoad = async ({ fetch }) => {
   //    ^?
   //    The nice thing about doing this is that you retain full typing for `sentence: string`.
 
-  /**
-   * However, if we want to pass the entire response, we call `.toJson()` since what's passed through the SSR boundary must be plain JSON.
-   *
-   * You may also need to do this if you use BigInts or byte array (byte arrays use UInt8Array).
-   */
-  const fullResponseJson = response.toJson();
-  //    ^?
-  //    The downside to this approach is that you lose all type information (but you can get it right back! see `SayResponse.fromJson` in +page.svelte).
-
   return {
     request,
     plainProperty,
-    fullResponseJson,
+    response,
   };
 }

--- a/svelte/src/routes/universal-ssr/+page.ts
+++ b/svelte/src/routes/universal-ssr/+page.ts
@@ -1,0 +1,46 @@
+import { ElizaService } from '../../gen/buf/connect/demo/eliza/v1/eliza_connect';
+import { SayRequest } from '../../gen/buf/connect/demo/eliza/v1/eliza_pb';
+import { createConnectTransport } from '@bufbuild/connect-web';
+import { createPromiseClient } from '@bufbuild/connect';
+import { wrapFetch } from '../../utils';
+import type { PageLoad } from './$types';
+
+// Note: take a look at `hooks.server.js`.  There's a bit of configuration there that the universal fetch handler depends on.
+
+export const load: PageLoad = async ({ fetch }) => {
+  const transport = createConnectTransport({
+    baseUrl: 'https://demo.connect.build',
+    fetch: wrapFetch('calling from connect in universal SSR', fetch),
+  });
+
+  const client = createPromiseClient(ElizaService, transport);
+
+  const request = {
+    sentence: "hi from the server",
+  };
+
+  const response = await client.say(new SayRequest(request));
+
+  /**
+   * The values on `response` (such as `sentence`) are regular JavaScript values.
+   * This means that we can easily pass them directly.
+   */
+  const plainProperty = response.sentence;
+  //    ^?
+  //    The nice thing about doing this is that you retain full typing for `sentence: string`.
+
+  /**
+   * However, if we want to pass the entire response, we call `.toJson()` since what's passed through the SSR boundary must be plain JSON.
+   *
+   * You may also need to do this if you use BigInts or byte array (byte arrays use UInt8Array).
+   */
+  const fullResponseJson = response.toJson();
+  //    ^?
+  //    The downside to this approach is that you lose all type information (but you can get it right back! see `SayResponse.fromJson` in +page.svelte).
+
+  return {
+    request,
+    plainProperty,
+    fullResponseJson,
+  };
+}

--- a/svelte/src/utils.ts
+++ b/svelte/src/utils.ts
@@ -1,0 +1,11 @@
+/** This utility helps to demonstrate that a custom implementation for fetch (first supplied by sveltekit then passed to Connect) is actually being called. */
+export const wrapFetch = (
+  message: string,
+  fetch: typeof globalThis.fetch,
+) => (
+  url: RequestInfo | URL,
+  init?: RequestInit | undefined,
+) => {
+  console.log(message)
+  return fetch(url, init)
+}


### PR DESCRIPTION
This PR adds two small SSR examples for Sveltekit demonstrating some of the differences between the universal and server-only handler modes.

### Root route
Some navigation was added for the new pages.
<img src="https://github.com/bufbuild/connect-es-integration/assets/15232461/3341b5af-1630-4e79-b8ad-5fa6c8981dd3" width="50%" />

### `/universal-ssr`
![Screenshot 2023-06-02 at 15 48 40](https://github.com/bufbuild/connect-es-integration/assets/15232461/bd387fca-2f1b-4fca-a4ce-8b654018cb56)

### `/server-only-ssr`
![Screenshot 2023-06-02 at 15 49 30](https://github.com/bufbuild/connect-es-integration/assets/15232461/b89a7a8a-ff82-4674-81cb-03d9f5ded171)

> note that there's no `calling from` happening here in the browser because it happened only on the server

<details>
<summary>note for @timostamm</summary>

I figured since I had all the context for what exactly needs to be done it will save the team some time/effort on the way to connect-es 1.0.

Feel free to modify this PR or close it or anything you wish: it's all good :+1: .  Just thought it could be helpful.

</details>